### PR TITLE
Remove duplicate twitter description meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
     <meta name="twitter:image" content="https://uselessknowledge.me/uselessknowledge.png">
     <meta name="twitter:site" content="@uselessknowledge">
     <meta name="twitter:creator" content="@uselessknowledge">
-    <meta name="twitter:description" content="Discover and share the fascinating 'useless knowledge' and hidden expertise people have outside their day jobs.">
     <meta name="twitter:image:alt" content="Useless Knowledge - Everyone's an Expert at Something">
     <meta name="twitter:image:width" content="1000">
     <meta name="twitter:image:height" content="1000">


### PR DESCRIPTION
## Summary
- delete redundant `twitter:description` meta tag in `index.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68592d61a7948327b8fa15c2cb16253b